### PR TITLE
use newer Docker image with Chrome and FF

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   cy-doc:
     docker:
-      - image: cypress/browsers:node13.6.0-chrome80-ff72
+      - image: cypress/browsers:node13.6.0-chrome-80-ff72
   node10:
     docker:
       - image: cypress/base:10.16.0

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   cy-doc:
     docker:
-      - image: cypress/browsers:chrome69
+      - image: cypress/browsers:node13.6.0-chrome80-ff72
   node10:
     docker:
       - image: cypress/base:10.16.0


### PR DESCRIPTION
- closes #80

Should fix errors

```
/proc/self/exe: /lib/x86_64-linux-gnu/libdbus-1.so.3: no version information available (required by /proc/self/exe)
/proc/self/exe: /lib/x86_64-linux-gnu/libdbus-1.so.3: no version information available (required by /proc/self/exe)
/root/.cache/Cypress/4.0.0/Cypress/Cypress: /lib/x86_64-linux-gnu/libdbus-1.so.3: no version information available (required by /root/.cache/Cypress/4.0.0/Cypress/Cypress)
```