### PR TITLE
Update circle to test against renamed repo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -198,7 +198,7 @@ jobs:
     steps:
       - prepare
       - run:
-          command: npm run test-if -- --repo cypress-example-realworld --command test
+          command: npm run test-if -- --repo cypress-example-conduit-app --command test
           timeout: '3 minutes'
       - set-failed-status
       - store-npm-logs


### PR DESCRIPTION
- Amir asked that the `cypress-example-realworld` repo be renamed so that it’s not confused with the new rwa.
- this updates our tests to run against the new name.