### PR TITLE
chore: comment out failing stages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -230,23 +230,23 @@ jobs:
   #     - set-failed-status
   #     - store-npm-logs
 
-  cypress-vue-unit-test:
-    <<: *defaults
-    steps:
-      - prepare
-      - run: npm run test-if -- --repo bahmutov/cypress-vue-unit-test --command test
-        # store NPM logs in case there was a problem
-      - set-failed-status
-      - store-npm-logs
+  # cypress-vue-unit-test:
+  #   <<: *defaults
+  #   steps:
+  #     - prepare
+  #     - run: npm run test-if -- --repo bahmutov/cypress-vue-unit-test --command test
+  #       # store NPM logs in case there was a problem
+  #     - set-failed-status
+  #     - store-npm-logs
 
-  cypress-react-unit-test:
-    <<: *defaults
-    steps:
-      - prepare
-      - run: npm run test-if -- --repo bahmutov/cypress-react-unit-test --command test
-        # store NPM logs in case there was a problem
-      - set-failed-status
-      - store-npm-logs
+  # cypress-react-unit-test:
+  #   <<: *defaults
+  #   steps:
+  #     - prepare
+  #     - run: npm run test-if -- --repo bahmutov/cypress-react-unit-test --command test
+  #       # store NPM logs in case there was a problem
+  #     - set-failed-status
+  #     - store-npm-logs
 
   workshop:
     <<: *defaults
@@ -364,10 +364,12 @@ workflows:
       # https://circleci.com/gh/cypress-io/cypress-test-example-repos/110563
       # - cypress-svelte-unit-test:
       #     context: test-runner:commit-status-checks
-      - cypress-vue-unit-test:
-          context: test-runner:commit-status-checks
-      - cypress-react-unit-test:
-          context: test-runner:commit-status-checks
+      # TODO: fix - extremely flaky in CI
+      # - cypress-vue-unit-test:
+      #     context: test-runner:commit-status-checks
+      # TODO: fix - extremely flaky in CI
+      # - cypress-react-unit-test:
+      #     context: test-runner:commit-status-checks
       - workshop:
           context: test-runner:commit-status-checks
       # after all jobs finish successfully
@@ -387,8 +389,8 @@ workflows:
             - phonecat
             - piechopper
             # - cypress-svelte-unit-test
-            - cypress-vue-unit-test
-            - cypress-react-unit-test
+            # - cypress-vue-unit-test
+            # - cypress-react-unit-test
             - workshop
             - cypress-example-reporters-mochawesome
             - cypress-example-reporters-junit


### PR DESCRIPTION
These have been failing for a long time in the monorepo... commenting out for now.

* react: 
	* https://app.circleci.com/pipelines/github/cypress-io/cypress-test-example-repos/6288/workflows/cae7751d-f8d7-4b07-a46f-53356fec46ea/jobs/153399
	* https://app.circleci.com/pipelines/github/cypress-io/cypress-test-example-repos/6279/workflows/891579df-8cfd-427a-919a-0d784869e36d/jobs/153221
* vue:
	* https://app.circleci.com/pipelines/github/cypress-io/cypress-test-example-repos/6284/workflows/4581f2e5-aacf-461e-9596-0e461e2cbb0c/jobs/153319
	* https://app.circleci.com/pipelines/github/cypress-io/cypress-test-example-repos/6275/workflows/0116c740-694a-4da6-9afb-db640de80747/jobs/153143

